### PR TITLE
Feature/dns logging

### DIFF
--- a/DNS response logger/crontab
+++ b/DNS response logger/crontab
@@ -1,0 +1,2 @@
+*/15 * * * *  /root/dns_logs/start_capture.sh > /tmp/cronlog 2>&1
+*/15 * * * *  /root/dns_logs/process.sh

--- a/DNS response logger/process.sh
+++ b/DNS response logger/process.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+ls -t /tmp/dns.pcap* | tail -n +2 | xargs -I {} /root/dns_logs/tocsv.py {}
+chown cloud:cloud /home/cloud/logs/*

--- a/DNS response logger/readme.md
+++ b/DNS response logger/readme.md
@@ -1,0 +1,11 @@
+# DNS server response logging
+---
+This is meant to live on a DNS server.
+It will dump CSV logs to /root/dns_logs/logs containing what IP address queried the server, asking for what domain and tho what we resolved it.
+
+  * Add the files to /root/dns_logs/
+  * Add the cron entries
+
+Low on memory, safe to leave on.
+Uses the graceful kill on the tcpdump command to neatly create it's log file
+

--- a/DNS response logger/start_capture.sh
+++ b/DNS response logger/start_capture.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#Get this servers IP
+IP=`/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}'`
+DATE=`date +%Y-%m-%d-%H:%M:%S`
+#Get the PID of the old running tcpdump
+PID=`ps aux | grep tcpdump | grep $IP | grep -v grep | tail -n1 | awk '{print $2}'`
+#When we kill it (-SIGINT) is the same as ctrl-C
+#It will rotate out, and we can grab the old one
+#echo PID
+#echo $PID
+#If $PID is not empty, kill it
+if [ ! -z "$PID" ]; then
+  kill -SIGINT $PID
+fi
+/usr/sbin/tcpdump -tttt -K -i eth0 -vvv -s 0 -l -n src host $IP and src port 53 > /tmp/dns.pcap-$DATE &2>>/tmp/tcpdumpError

--- a/DNS response logger/tocsv.py
+++ b/DNS response logger/tocsv.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+import datetime
+import itertools
+import shutil
+import csv
+import sys
+import os
+fname=sys.argv[1]
+curDate = datetime.datetime.now().date()
+curTime = datetime.datetime.now().time()
+outputArr = []#[["time","realIP","queryType","queriedDomain","results"]]
+with open(fname) as f:
+#at some time, test that it starts with a date for line1
+    for line1,line2 in itertools.izip_longest(*[f]*2):
+	time = line1[:19]+"+02:00"
+	if line2 and not "ServFail" in line2:
+
+
+	    clipped = line2.split("> ",1)[1]
+	    ipport = clipped.split(":",1)[0]
+	    realIP = ipport.rsplit(".",1)[0]
+	    query = clipped.split("q: ",1)
+	    if (len(query)!=1):
+		queryType = query[1].rsplit("? ",1)
+		if (queryType[0] == "A"):
+#		    print "queryType"
+#		    print queryType
+		    queriedDomain = queryType[1].split(". ")[0]
+		    reply = queryType[1].split(" A ")
+		    cname = 0
+
+		    resultIP=""
+		    if len(reply)!=1:
+#			print "reply"
+			count = 0
+			for block in reply:
+			    if count == 1:
+#				print block
+				IP = block.split(" ")[0]
+				IP = IP.split(",")[0]
+				if resultIP != "":
+				    resultIP = resultIP + ","
+				resultIP = resultIP + IP
+				#If we see NS in block, we know the only IP's to follow are those of NS servers....
+				if " NS " in block:
+				    break
+			    count = 1
+		    if resultIP != "":
+			outputArr.append([time,realIP,queriedDomain,resultIP])
+
+#for row in outputArr:
+#    print row
+outfile="/root/dns_logs/logs/dns_logs"+"_"+str(curDate)+"_"+str(curTime)
+#Add some safety to deleting stuff
+if "/tmp/dns.pcap" in fname:
+#    shutil.move(fname,"/tmp/oldFiles/")
+    os.remove(fname)
+with open(outfile, "w") as out:
+    writer = csv.writer(out)
+    writer.writerows(outputArr)


### PR DESCRIPTION
Added a DNS logging system that will capture DNS server responses.

This can live on the server as it has a low memory footprint,  is very useful to determine where your DNS server sent a user to.

Can be combined with firewall logs to make a quick and dirty non-proxy based dns aware logging system